### PR TITLE
fix: enable merge tags

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -15,21 +15,18 @@ export function showError(error: any) {
 	vscode.window.showErrorMessage(message);
 }
 
-type StringifyYamlOptions = YAML.SchemaOptions & YAML.ToStringOptions;
-
 export function getYamlFromJson(json: string): string {
 	const indent = getConfig<Configs['YamlIndent']>(ConfigId.YamlIndent);
 	const schema = getConfig<Configs['YamlSchema']>(ConfigId.YamlSchema);
-
-	const options: StringifyYamlOptions = {
-		...(indent && { indent }),
-		...(schema && { schema }),
-	};
-
+	
 	try {
 		const jsonObject = JSON.parse(json);
-
-		return YAML.stringify(jsonObject, options);
+		
+		return YAML.stringify(jsonObject, {
+			...(indent && { indent }),
+			...(schema && { schema }),
+			merge: true
+		});
 	} catch (error) {
 		console.error(error);
 		throw new Error('Failed to parse YAML. Please make sure it has a valid format and try again.');
@@ -37,8 +34,13 @@ export function getYamlFromJson(json: string): string {
 }
 
 export function getJsonFromYaml(yaml: string): string {
+	const schema = getConfig<Configs['YamlSchema']>(ConfigId.YamlSchema);
+	
 	try {
-		const json = YAML.parse(yaml, {});
+		const json = YAML.parse(yaml, {
+			merge: true,
+			...(schema && { schema })
+		});
 
 		return JSON.stringify(json, undefined, 2);
 	} catch (error) {

--- a/src/test/fixtures/expectedMergeTag.json
+++ b/src/test/fixtures/expectedMergeTag.json
@@ -1,0 +1,17 @@
+{
+  "anchor": {
+    "first": 1,
+    "second": 2,
+    "other": "the default"
+  },
+  "alias": {
+    "first": 1,
+    "second": 2,
+    "other": "the default"
+  },
+  "merge": {
+    "first": 1,
+    "second": 2,
+    "other": "not the default"
+  }
+}

--- a/src/test/fixtures/inputMergeTag.yaml
+++ b/src/test/fixtures/inputMergeTag.yaml
@@ -1,0 +1,8 @@
+anchor: &default
+  first: 1
+  second: 2
+  other : the default
+alias: *default
+merge: 
+  <<: *default
+  other: not the default

--- a/src/test/suite/helpers.test.ts
+++ b/src/test/suite/helpers.test.ts
@@ -23,9 +23,20 @@ suite('helpers', () => {
 				loadFixture('input.yaml'),
 				loadFixture('expected.json'),
 			]);
-	
+
 			const actualJson = getJsonFromYaml(yamlInput);
-	
+
+			assert.deepStrictEqual(stripNewLines(actualJson), stripNewLines(expectedJson));
+		});
+
+		test('should convert json to yaml with merge tags', async () => {
+			const [yamlInput, expectedJson] = await Promise.all([
+				loadFixture('inputMergeTag.yaml'),
+				loadFixture('expectedMergeTag.json'),
+			]);
+
+			const actualJson = getJsonFromYaml(yamlInput);
+
 			assert.deepStrictEqual(stripNewLines(actualJson), stripNewLines(expectedJson));
 		});
 	});


### PR DESCRIPTION
Set `merge: true` when stringifying and parsing yaml, as specified accordingly in the [yaml package](https://eemeli.org/yaml/#schema-options) via function-options.

Fixes https://github.com/hilleer/vscode-yaml-plus-json/issues/38.