### PR TITLE
Configure default naming convention for target files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,21 +41,27 @@ All configurations should be defined in `yaml-plus-json` in vscode settings (e.g
     "fileExtensions": {
       "yaml": ".yaml",
       "json": ".json"
+    },
+    "enforceNamingConvention": {
+      "yaml": "kebab-kase",
+      "json": "none"
     }
   }
 }
 ```
 
-| id                       | description                                                                                                               | type    | default   | example    |
-|--------------------------|---------------------------------------------------------------------------------------------------------------------------|---------|-----------|------------|
-| `convertOnRename`        | Convert YAML/JSON files on rename                                                                                         | boolean | `true`    | `false`    |
-| `yamlIndent`             | The number of spaces to use when indenting code (yaml)                                                                    | number  | `2`       | `4`        |
-| `yamlSchema`             | See [yaml module documentation](https://github.com/eemeli/yaml/blob/master/docs/03_options.md#schema-options) for details | string  | `"core"`  | `"json"`   |
-| `fileExtensions`         | define what filename extension(s) to use when converting file(s)                                                          | object  |           |            |
-| `fileExtensions.yaml`    | yaml filename extension                                                                                                   | string  | `".yaml"` | `".yml"`   |
-| `fileExtensions.json`    | json filename extension                                                                                                   | string  | `".json"` | `".json"`  |
-| `keepOriginalFiles`      | Keep original files when converting. Use `"ask"` to be asked every time or `"always"` to always keep original files       | string  |           | `"always"` |
-| `overwriteExistentFiles` | Overwrite existent files when converting. Use `"ask"` to be asked every time or `"always"` to always overwrite            | string  |           | `"always"` |
+| id                                | description                                                                                                               | type    | default   | example          |
+|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------|---------|-----------|------------------|
+| `convertOnRename`                 | Convert YAML/JSON files on rename                                                                                         | boolean | `true`    | `false`          |
+| `yamlIndent`                      | The number of spaces to use when indenting code (yaml)                                                                    | number  | `2`       | `4`              |
+| `yamlSchema`                      | See [yaml module documentation](https://github.com/eemeli/yaml/blob/master/docs/03_options.md#schema-options) for details | string  | `"core"`  | `"json"`         |
+| `fileExtensions`                  | define what filename extension(s) to use when converting file(s)                                                          | object  |           |                  |
+| `fileExtensions.yaml`             | yaml filename extension                                                                                                   | string  | `".yaml"` | `".yml"`         |
+| `fileExtensions.json`             | json filename extension                                                                                                   | string  | `".json"` | `".json"`        |
+| `enforceNamingConvention.yaml`    | apply a naming convention to converted yaml files                                                                         | string  | `"none"`  | `"kebab-case"`   |
+| `enforceNamingConvention.json`    | apply a naming convention to converted json files                                                                         | string  | `"none"`  | `"PascalCase"`   |
+| `keepOriginalFiles`               | Keep original files when converting. Use `"ask"` to be asked every time or `"always"` to always keep original files       | string  |           | `"always"`       |
+| `overwriteExistentFiles`          | Overwrite existent files when converting. Use `"ask"` to be asked every time or `"always"` to always overwrite            | string  |           | `"always"`       |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Any good ideas or feature requests? Please, do not hesitate to open [a new issue
 
 * Reverting converted files: When a file has been reverted, a _"revert"_ prompt will be shown to revert it. Using this will return the entirety of the original file, including YAML comments.
 * Overwriting existent files: When trying to convert a file into a destination that already exist, you can use the `overwriteExistentFiles` configuration to overwrite such. **Notice** if you use the revert feature after overwriting a file, the extension cannot (currently) revert the overwritten file. Also, due to limitation in vscode of active user prompts, if you set it to `"ask"` you will only be prompted to overwrite N number of files, while others will be skipped.
+* Converted files can enforce a naming convention on property keys by setting `enforceNamingConvention` in config. This will apply the configured naming convention to converted properties
 
 ## Config
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "yaml-plus-json",
 	"displayName": "YAML ❤️ JSON",
 	"description": "Easily convert yaml to json and json to yaml",
-	"version": "1.12.1",
+	"version": "1.12.2",
 	"publisher": "hilleer",
 	"engines": {
 		"vscode": "^1.75.1"
@@ -13,6 +13,11 @@
 			"name": "Daniel Hillmann",
 			"url": "https://github.com/hilleer",
 			"email": "hiller@live.dk"
+		},
+		{
+			"name": "Michael Stocks",
+			"url": "https://github.com/Droxx",
+			"email": "michaelstocks1@gmail.com"
 		}
 	],
 	"categories": [

--- a/package.json
+++ b/package.json
@@ -233,6 +233,34 @@
 									}
 								}
 							},
+							"enforceNamingConvention":{
+								"type": "object",
+								"description": "enforce naming convention when converting file(s)",
+								"properties": {
+									"yaml": {
+										"type": "string",
+										"description": "yaml target naming convention",
+										"enum": [
+											"kebab-case",
+											"snake_case",
+											"camelCase",
+											"PascalCase",
+											"none"	
+										]
+									},
+									"json": {
+										"type": "string",
+										"description": "json target naming convention",
+										"enum": [
+											"kebab-case",
+											"snake_case",
+											"camelCase",
+											"PascalCase",
+											"none"
+										]
+									}
+								}	
+							},
 							"keepOriginalFiles": {
 								"type": [
 									"string"

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,8 @@ export enum ConfigId {
 	YamlIndent = 'yamlIndent',
 	FileExtensionsYaml = 'fileExtensions.yaml',
 	FileExtensionsJson = 'fileExtensions.json',
+	EnforceNamingConventionYaml = 'enforceNamingConvention.yaml',
+	EnforceNamingConventionJson = 'enforceNamingConvention.json',
 	KeepOriginalFiles = 'keepOriginalFiles',
 	OverwriteExistentFiles = 'overwriteExistentFiles'
 }
@@ -15,7 +17,16 @@ export type Configs = {
 	overwriteExistentFiles: 'ask' | 'always';
 	YamlSchema: 'core' | 'failsafe' | 'json' | 'yaml-1.1';
 	YamlIndent: number;
+	EnforceNamingConvention: NamingConvention;
 };
+
+export enum NamingConvention {
+	None = 'none',	
+	Pascal = 'PascalCase',
+	Camel = 'camelCase',
+	Snake = 'snake_case',
+	Kebab = 'kebab-case'
+}
 
 enum ConfigIdLegacy {
 	// Same key as new - only here for convenience

--- a/src/conventions.ts
+++ b/src/conventions.ts
@@ -1,0 +1,114 @@
+import { NamingConvention } from './config';
+
+export function getConventionFunction(toCase: NamingConvention): (kIn: string) => string{
+    const converter = {
+        [NamingConvention.Camel]: toCamel,
+        [NamingConvention.Pascal]: toPascal,
+        [NamingConvention.Snake]: toSnake,
+        [NamingConvention.Kebab]: toKebab,
+        [NamingConvention.None]: (str: string) => str
+    }[toCase];
+
+    return converter;
+}
+
+export function changeObjectKeys(oIn: object, caseChange: (kIn: string) => string): object{
+    return Object.keys(oIn).reduce(function (newObj, key) {
+        // @ts-ignore
+        let val = oIn[key];
+        let newVal = (typeof val === 'object') ? changeObjectKeys(val, caseChange) : val;
+        if(Object.prototype.toString.call(val) !== '[object Array]'){
+            // @ts-ignore
+            newObj[caseChange(key)] = newVal;
+        }
+        else{
+            // @ts-ignore
+            newObj[caseChange(key)] = Object.values(newVal);
+        }
+        return newObj;
+    }, {});
+}
+
+function toCamel(kIn: string): string{
+    var originalConvention = detectConvention(kIn);
+    if(originalConvention === NamingConvention.Pascal || originalConvention === NamingConvention.Camel)
+    {
+        return kIn[0].toLowerCase() + kIn.slice(1);
+    }
+    if(originalConvention === NamingConvention.Snake)
+    {
+        return kIn.split('_').map((s, i) => i > 0 ? s[0].toUpperCase() + s.slice(1) : s[0].toLowerCase() + s.slice(1)).join('');
+    }
+    if(originalConvention === NamingConvention.Kebab)
+    {
+        return kIn.split('-').map((s, i) => i > 0 ? s[0].toUpperCase() + s.slice(1) : s[0].toLowerCase() + s.slice(1)).join('');
+    }
+    return kIn;
+}
+
+function toPascal(kIn: string): string{
+    var originalConvention = detectConvention(kIn);
+    if(originalConvention === NamingConvention.Pascal || originalConvention === NamingConvention.Camel)
+    {
+        return kIn[0].toUpperCase() + kIn.slice(1);
+    }
+    if(originalConvention === NamingConvention.Snake)
+    {
+        return kIn.split('_').map((s, i) => s[0].toUpperCase() + s.slice(1)).join('');
+    }
+    if(originalConvention === NamingConvention.Kebab)
+    {
+        return kIn.split('-').map((s, i) => s[0].toUpperCase() + s.slice(1)).join('');
+    }
+    return kIn;
+}
+
+function toKebab(kIn: string): string{
+    var originalConvention = detectConvention(kIn);
+    if(originalConvention === NamingConvention.Pascal || originalConvention === NamingConvention.Camel)
+    {
+        return kIn.split(/(?=[A-Z])/).join('-').toLowerCase();
+    }
+    if(originalConvention === NamingConvention.Snake)
+    {
+        return kIn.split('_').join('-');
+    }
+    if(originalConvention === NamingConvention.Kebab)
+    {
+        return kIn;
+    }
+    return kIn;
+}
+
+function toSnake(kIn: string): string{
+    var originalConvention = detectConvention(kIn);
+    if(originalConvention === NamingConvention.Pascal || originalConvention === NamingConvention.Camel)
+    {
+        return kIn.split(/(?=[A-Z])/).join('_').toLowerCase();
+    }
+    if(originalConvention === NamingConvention.Snake)
+    {
+        return kIn;
+    }
+    if(originalConvention === NamingConvention.Kebab)
+    {
+        return kIn.split('-').join('_');
+    }
+    return kIn;
+}
+
+function detectConvention(sIn: string): NamingConvention{
+    if(sIn.slice(1).includes('_')){
+        return NamingConvention.Snake;
+    }
+    if(sIn.slice(1).includes('-')){
+        return NamingConvention.Kebab;
+    }
+    if(sIn[0] === sIn[0].toLowerCase()){
+        return NamingConvention.Camel;
+    }
+    if(sIn[0] === sIn[0].toUpperCase()){
+        return NamingConvention.Pascal;
+    }
+    return NamingConvention.None;
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 import * as YAML from 'yaml';
 
-import { ConfigId, Configs, getConfig, NamingConvention } from './config';
+import { ConfigId, Configs, getConfig } from './config';
+import { getConventionFunction, changeObjectKeys } from './conventions';
 
 const DEFAULT_ERROR_MESSAGE = 'Something went wrong, please validate your file and try again or create an issue if the problem persist';
 
@@ -61,115 +62,4 @@ export function getJsonFromYaml(yaml: string): string {
 	}
 }
 
-function getConventionFunction(toCase: NamingConvention): (kIn: string) => string{
-    const converter = {
-        [NamingConvention.Camel]: toCamel,
-        [NamingConvention.Pascal]: toPascal,
-        [NamingConvention.Snake]: toSnake,
-        [NamingConvention.Kebab]: toKebab,
-        [NamingConvention.None]: (str: string) => str
-    }[toCase];
 
-    return converter;
-}
-
-function changeObjectKeys(oIn: object, caseChange: (kIn: string) => string): object{
-    return Object.keys(oIn).reduce(function (newObj, key) {
-        // @ts-ignore
-        let val = oIn[key];
-        let newVal = (typeof val === 'object') ? changeObjectKeys(val, caseChange) : val;
-        if(Object.prototype.toString.call(val) !== '[object Array]'){
-            // @ts-ignore
-            newObj[caseChange(key)] = newVal;
-        }
-        else{
-            // @ts-ignore
-            newObj[caseChange(key)] = Object.values(newVal);
-        }
-        return newObj;
-    }, {});
-}
-
-function toCamel(kIn: string): string{
-    var originalConvention = detectConvention(kIn);
-    if(originalConvention === NamingConvention.Pascal || originalConvention === NamingConvention.Camel)
-    {
-        return kIn[0].toLowerCase() + kIn.slice(1);
-    }
-    if(originalConvention === NamingConvention.Snake)
-    {
-        return kIn.split('_').map((s, i) => i > 0 ? s[0].toUpperCase() + s.slice(1) : s[0].toLowerCase() + s.slice(1)).join('');
-    }
-    if(originalConvention === NamingConvention.Kebab)
-    {
-        return kIn.split('-').map((s, i) => i > 0 ? s[0].toUpperCase() + s.slice(1) : s[0].toLowerCase() + s.slice(1)).join('');
-    }
-    return kIn;
-}
-
-function toPascal(kIn: string): string{
-    var originalConvention = detectConvention(kIn);
-    if(originalConvention === NamingConvention.Pascal || originalConvention === NamingConvention.Camel)
-    {
-        return kIn[0].toUpperCase() + kIn.slice(1);
-    }
-    if(originalConvention === NamingConvention.Snake)
-    {
-        return kIn.split('_').map((s, i) => s[0].toUpperCase() + s.slice(1)).join('');
-    }
-    if(originalConvention === NamingConvention.Kebab)
-    {
-        return kIn.split('-').map((s, i) => s[0].toUpperCase() + s.slice(1)).join('');
-    }
-    return kIn;
-}
-
-function toKebab(kIn: string): string{
-    var originalConvention = detectConvention(kIn);
-    if(originalConvention === NamingConvention.Pascal || originalConvention === NamingConvention.Camel)
-    {
-        return kIn.split(/(?=[A-Z])/).join('-').toLowerCase();
-    }
-    if(originalConvention === NamingConvention.Snake)
-    {
-        return kIn.split('_').join('-');
-    }
-    if(originalConvention === NamingConvention.Kebab)
-    {
-        return kIn;
-    }
-    return kIn;
-}
-
-function toSnake(kIn: string): string{
-    var originalConvention = detectConvention(kIn);
-    if(originalConvention === NamingConvention.Pascal || originalConvention === NamingConvention.Camel)
-    {
-        return kIn.split(/(?=[A-Z])/).join('_').toLowerCase();
-    }
-    if(originalConvention === NamingConvention.Snake)
-    {
-        return kIn;
-    }
-    if(originalConvention === NamingConvention.Kebab)
-    {
-        return kIn.split('-').join('_');
-    }
-    return kIn;
-}
-
-function detectConvention(sIn: string): NamingConvention{
-    if(sIn.slice(1).includes('_')){
-        return NamingConvention.Snake;
-    }
-    if(sIn.slice(1).includes('-')){
-        return NamingConvention.Kebab;
-    }
-    if(sIn[0] === sIn[0].toLowerCase()){
-        return NamingConvention.Camel;
-    }
-    if(sIn[0] === sIn[0].toUpperCase()){
-        return NamingConvention.Pascal;
-    }
-    return NamingConvention.None;
-}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as YAML from 'yaml';
 
-import { ConfigId, Configs, getConfig } from './config';
+import { ConfigId, Configs, getConfig, NamingConvention } from './config';
 
 const DEFAULT_ERROR_MESSAGE = 'Something went wrong, please validate your file and try again or create an issue if the problem persist';
 
@@ -18,9 +18,15 @@ export function showError(error: any) {
 export function getYamlFromJson(json: string): string {
 	const indent = getConfig<Configs['YamlIndent']>(ConfigId.YamlIndent);
 	const schema = getConfig<Configs['YamlSchema']>(ConfigId.YamlSchema);
+	const nConvention = getConfig<Configs['EnforceNamingConvention']>(ConfigId.EnforceNamingConventionYaml);
 	
 	try {
-		const jsonObject = JSON.parse(json);
+		let jsonObject = JSON.parse(json);
+
+		if(nConvention !== 'none' && nConvention !== undefined) {
+			let cFunc = getConventionFunction(nConvention!);
+			jsonObject = changeObjectKeys(jsonObject, cFunc);
+		}
 		
 		return YAML.stringify(jsonObject, {
 			...(indent && { indent }),
@@ -35,16 +41,135 @@ export function getYamlFromJson(json: string): string {
 
 export function getJsonFromYaml(yaml: string): string {
 	const schema = getConfig<Configs['YamlSchema']>(ConfigId.YamlSchema);
+	const nConvention = getConfig<Configs['EnforceNamingConvention']>(ConfigId.EnforceNamingConventionJson);
 	
 	try {
-		const json = YAML.parse(yaml, {
+		let json = YAML.parse(yaml, {
 			merge: true,
 			...(schema && { schema })
 		});
+
+		if(nConvention !== 'none' && nConvention !== undefined) {
+			let cFunc = getConventionFunction(nConvention!);
+			json = changeObjectKeys(json, cFunc);
+		}
 
 		return JSON.stringify(json, undefined, 2);
 	} catch (error) {
 		console.error(error);
 		throw new Error('Failed to parse JSON. Please make sure it has a valid format and try again.');
 	}
+}
+
+function getConventionFunction(toCase: NamingConvention): (kIn: string) => string{
+    const converter = {
+        [NamingConvention.Camel]: toCamel,
+        [NamingConvention.Pascal]: toPascal,
+        [NamingConvention.Snake]: toSnake,
+        [NamingConvention.Kebab]: toKebab,
+        [NamingConvention.None]: (str: string) => str
+    }[toCase];
+
+    return converter;
+}
+
+function changeObjectKeys(oIn: object, caseChange: (kIn: string) => string): object{
+    return Object.keys(oIn).reduce(function (newObj, key) {
+        // @ts-ignore
+        let val = oIn[key];
+        let newVal = (typeof val === 'object') ? changeObjectKeys(val, caseChange) : val;
+        if(Object.prototype.toString.call(val) !== '[object Array]'){
+            // @ts-ignore
+            newObj[caseChange(key)] = newVal;
+        }
+        else{
+            // @ts-ignore
+            newObj[caseChange(key)] = Object.values(newVal);
+        }
+        return newObj;
+    }, {});
+}
+
+function toCamel(kIn: string): string{
+    var originalConvention = detectConvention(kIn);
+    if(originalConvention === NamingConvention.Pascal || originalConvention === NamingConvention.Camel)
+    {
+        return kIn[0].toLowerCase() + kIn.slice(1);
+    }
+    if(originalConvention === NamingConvention.Snake)
+    {
+        return kIn.split('_').map((s, i) => i > 0 ? s[0].toUpperCase() + s.slice(1) : s[0].toLowerCase() + s.slice(1)).join('');
+    }
+    if(originalConvention === NamingConvention.Kebab)
+    {
+        return kIn.split('-').map((s, i) => i > 0 ? s[0].toUpperCase() + s.slice(1) : s[0].toLowerCase() + s.slice(1)).join('');
+    }
+    return kIn;
+}
+
+function toPascal(kIn: string): string{
+    var originalConvention = detectConvention(kIn);
+    if(originalConvention === NamingConvention.Pascal || originalConvention === NamingConvention.Camel)
+    {
+        return kIn[0].toUpperCase() + kIn.slice(1);
+    }
+    if(originalConvention === NamingConvention.Snake)
+    {
+        return kIn.split('_').map((s, i) => s[0].toUpperCase() + s.slice(1)).join('');
+    }
+    if(originalConvention === NamingConvention.Kebab)
+    {
+        return kIn.split('-').map((s, i) => s[0].toUpperCase() + s.slice(1)).join('');
+    }
+    return kIn;
+}
+
+function toKebab(kIn: string): string{
+    var originalConvention = detectConvention(kIn);
+    if(originalConvention === NamingConvention.Pascal || originalConvention === NamingConvention.Camel)
+    {
+        return kIn.split(/(?=[A-Z])/).join('-').toLowerCase();
+    }
+    if(originalConvention === NamingConvention.Snake)
+    {
+        return kIn.split('_').join('-');
+    }
+    if(originalConvention === NamingConvention.Kebab)
+    {
+        return kIn;
+    }
+    return kIn;
+}
+
+function toSnake(kIn: string): string{
+    var originalConvention = detectConvention(kIn);
+    if(originalConvention === NamingConvention.Pascal || originalConvention === NamingConvention.Camel)
+    {
+        return kIn.split(/(?=[A-Z])/).join('_').toLowerCase();
+    }
+    if(originalConvention === NamingConvention.Snake)
+    {
+        return kIn;
+    }
+    if(originalConvention === NamingConvention.Kebab)
+    {
+        return kIn.split('-').join('_');
+    }
+    return kIn;
+}
+
+function detectConvention(sIn: string): NamingConvention{
+    if(sIn.slice(1).includes('_')){
+        return NamingConvention.Snake;
+    }
+    if(sIn.slice(1).includes('-')){
+        return NamingConvention.Kebab;
+    }
+    if(sIn[0] === sIn[0].toLowerCase()){
+        return NamingConvention.Camel;
+    }
+    if(sIn[0] === sIn[0].toUpperCase()){
+        return NamingConvention.Pascal;
+    }
+    return NamingConvention.None;
 }


### PR DESCRIPTION
Added the ability to configure a target naming convention. When this is set, converted files will have a naming convention applied to the target files.

Supported conventions include
PascalCase
camelCase
kebab-case
snake_case